### PR TITLE
Chore/unused declarations

### DIFF
--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -4,6 +4,7 @@
 #include "literal/wrapper.h"
 #include "righthand/righthand.h"
 #include "righthand/declaration/function_declaration.h"
+#include "righthand/declaration/struct_declaration.h"
 #include "righthand/declaration/variable_declaration.h"
 #include "statement/scope.h"
 #include "statement/statement.h"
@@ -36,6 +37,7 @@ void compile(void* void_node, String* line, Compiler* compiler) {
         [NodeStructType] = &comp_StructType,
         [NodeStructLiteral] = &comp_StructLiteral,
         [NodeCast] = &comp_Cast,
+        [NodeStructDeclaration] = &comp_StructDeclaration,
     };
 
     Node* const node = void_node;

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -12,7 +12,7 @@
 
 String new_line(Compiler* const compiler) {
     const String indent = compiler->sections.data[compiler->open_section].indent;
-    return strf(0, "%.*s", PRINT(indent));
+    return strf(0, "%.*s", FMT(indent));
 }
 
 void compile(void* void_node, String* line, Compiler* compiler) {
@@ -31,6 +31,7 @@ void compile(void* void_node, String* line, Compiler* compiler) {
         [NodePointerType] = &comp_PointerType,
         [NodeFunctionType] = &comp_FunctionType,
         [NodeFunctionDeclaration] = &comp_FunctionDeclaration,
+        [NodeEntryFunctionDeclaration] = &comp_FunctionDeclaration,
         [NodeStatementWrapper] = &comp_StatementWrapper,
         [NodeReturnStatement] = &comp_ReturnStatement,
         [NodeControlStatement] = &comp_ControlStatement,

--- a/src/compiler/compiler.h
+++ b/src/compiler/compiler.h
@@ -8,10 +8,10 @@ typedef struct {
     String indent;
 } CompilerSection;
 
-typedef Vector(CompilerSection) CompilerSections;
+typedef Vector(CompilerSection) CompilerSectionVector;
 
 struct Compiler {
-    CompilerSections sections;
+    CompilerSectionVector sections;
     size_t open_section;
     MessageVector* messages;
 };

--- a/src/compiler/literal/literals.c
+++ b/src/compiler/literal/literals.c
@@ -12,14 +12,14 @@ void comp_Missing(void* void_self, String* line, Compiler* compiler) {
     Missing* const self = void_self;
 
     push(compiler->messages,
-         REPORT_ERR(self->trace, strf(0, "cannot find '\33[35m%.*s\33[0m' in scope", PRINT(self->trace.source))));
+         REPORT_ERR(self->trace, strf(0, "cannot find '\33[35m%.*s\33[0m' in scope", FMT(self->trace.source))));
 }
 
 void comp_External(void* void_self, String* line, Compiler* compiler) {
     (void) compiler;
     External* const self = void_self;
 
-    strf(line, "%.*s", PRINT(self->data));
+    strf(line, "%.*s", FMT(self->data));
 }
 
 void comp_StructLiteral(void* void_self, String* line, Compiler* compiler) {
@@ -32,7 +32,7 @@ void comp_StructLiteral(void* void_self, String* line, Compiler* compiler) {
     for(size_t i = 0; i < self->field_values.size; i++) {
         strf(line, i ? ", " : " ");
         if(self->field_names.data[i].size) {
-            strf(line, ".%.*s = ", PRINT(self->field_names.data[i]));
+            strf(line, ".%.*s = ", FMT(self->field_names.data[i]));
         }
         compile(self->field_values.data[i], line, compiler);
     }

--- a/src/compiler/literal/wrapper.c
+++ b/src/compiler/literal/wrapper.c
@@ -8,6 +8,7 @@ void comp_Variable(void* void_self, String* line, Compiler* compiler) {
     const bool applied_action = apply_action(self->action, 0);
 
     Node* const const_value = self->Variable.declaration->const_value;
+    compile(self->Variable.declaration, line, compiler);
     if(const_value && const_value->flags & fConstExpr) {
         if(!(self->flags & fType)) {
             strf(line, "((");
@@ -21,7 +22,6 @@ void comp_Variable(void* void_self, String* line, Compiler* compiler) {
             strf(line, ")");
         }
     } else {
-        compile(self->Variable.declaration, line, compiler);
         compile_identifier(self->Variable.declaration->identifier, line);
     }
 

--- a/src/compiler/literal/wrapper.c
+++ b/src/compiler/literal/wrapper.c
@@ -7,8 +7,12 @@ void comp_Variable(void* void_self, String* line, Compiler* compiler) {
     Wrapper* const self = void_self;
     const bool applied_action = apply_action(self->action, 0);
 
+    if(self->Variable.declaration->compilation_state != CompilationHoisted) {
+        compile(self->Variable.declaration, line, compiler);
+    }
+
     Node* const const_value = self->Variable.declaration->const_value;
-    compile(self->Variable.declaration, line, compiler);
+
     if(const_value && const_value->flags & fConstExpr) {
         if(!(self->flags & fType)) {
             strf(line, "((");
@@ -22,7 +26,10 @@ void comp_Variable(void* void_self, String* line, Compiler* compiler) {
             strf(line, ")");
         }
     } else {
-        compile_identifier(self->Variable.declaration->identifier, line);
+        String identifier = { 0 };
+        resolve_identifier(self->Variable.declaration->identifier, &identifier);
+        strf(line, "%.*s", FMT(identifier));
+        free(identifier.data);
     }
 
     if(applied_action) remove_action(self->action, 0);
@@ -46,9 +53,9 @@ void comp_Surround(void* void_self, String* line, Compiler* compiler) {
     Wrapper* const self = void_self;
     const bool applied_action = apply_action(self->action, 0);
 
-    strf(line, "%.*s", PRINT(self->Surround.prefix));
+    strf(line, "%.*s", FMT(self->Surround.prefix));
     compile(self->Surround.child, line, compiler);
-    strf(line, "%.*s", PRINT(self->Surround.postfix));
+    strf(line, "%.*s", FMT(self->Surround.postfix));
 
     if(applied_action) remove_action(self->action, 0);
 }

--- a/src/compiler/literal/wrapper.c
+++ b/src/compiler/literal/wrapper.c
@@ -21,6 +21,7 @@ void comp_Variable(void* void_self, String* line, Compiler* compiler) {
             strf(line, ")");
         }
     } else {
+        compile(self->Variable.declaration, line, compiler);
         compile_identifier(self->Variable.declaration->identifier, line);
     }
 
@@ -29,6 +30,7 @@ void comp_Variable(void* void_self, String* line, Compiler* compiler) {
 
 void comp_Auto(void* void_self, String* line, Compiler* compiler) {
     Wrapper* const self = void_self;
+    // TODO: remove boolean result from apply_action
     const bool applied_action = apply_action(self->action, 0);
 
     if(!self->Auto.ref) {

--- a/src/compiler/righthand/declaration/function_declaration.c
+++ b/src/compiler/righthand/declaration/function_declaration.c
@@ -25,7 +25,7 @@ static void function_declaration_compiler_hoisted(FunctionDeclaration* const sel
         }
     }
     strf(&declaration_line, hoisted ? ");" : ") {");
-    push(&compiler->sections.data[(size_t) hoisted ? (size_t) hoisted : section].lines, declaration_line);
+    push(&compiler->sections.data[!hoisted * section].lines, declaration_line);
 
     if(hoisted) {
         compiler->open_section = previous_section;
@@ -43,10 +43,11 @@ void comp_FunctionDeclaration(void* void_self, String* line, Compiler* compiler)
     (void) line;
     FunctionDeclaration* self = void_self;
 
-    if(self->identifier.is_external || self->skip_compilation
+    if(self->identifier.is_external || self->compilation_state == CompilationSkip
        || (self->generics.base_type_arguments.size && !self->generics.type_arguments_stack.size))
         return;
 
     function_declaration_compiler_hoisted(self, compiler, true);
+    self->compilation_state = CompilationSkip;
     function_declaration_compiler_hoisted(self, compiler, false);
 }

--- a/src/compiler/righthand/declaration/function_declaration.c
+++ b/src/compiler/righthand/declaration/function_declaration.c
@@ -43,8 +43,8 @@ void comp_FunctionDeclaration(void* void_self, String* line, Compiler* compiler)
     (void) line;
     FunctionDeclaration* self = void_self;
 
-    if(self->identifier.is_external || (self->generics.base_type_arguments.size
-                                        && !self->generics.type_arguments_stack.size))
+    if(self->identifier.is_external || self->skip_compilation
+       || (self->generics.base_type_arguments.size && !self->generics.type_arguments_stack.size))
         return;
 
     function_declaration_compiler_hoisted(self, compiler, true);

--- a/src/compiler/righthand/declaration/function_declaration.c
+++ b/src/compiler/righthand/declaration/function_declaration.c
@@ -3,7 +3,7 @@
 #include "identifier.h"
 
 static void function_declaration_compiler_hoisted(FunctionDeclaration* const self, Compiler* compiler,
-                                                  const bool hoisted) {
+                                                  String identifier, const bool hoisted) {
     const size_t previous_section = compiler->open_section;
     const size_t section = compiler->open_section = compiler->sections.size;
     push(&compiler->sections, (CompilerSection) { 0 });
@@ -11,8 +11,7 @@ static void function_declaration_compiler_hoisted(FunctionDeclaration* const sel
     String declaration_line = new_line(compiler);
 
     compile(self->type->FunctionType.signature.data[0], &declaration_line, compiler);
-    strf(&declaration_line, " ");
-    compile_identifier(self->identifier, &declaration_line);
+    strf(&declaration_line, " %.*s", FMT(identifier));
 
     strf(&declaration_line, "(");
     for(size_t i = 0; i < self->arguments.size; i++) {
@@ -21,7 +20,7 @@ static void function_declaration_compiler_hoisted(FunctionDeclaration* const sel
         compile(self->arguments.data[i].type, &declaration_line, compiler);
         if(!hoisted) {
             strf(&declaration_line, " ");
-            compile_identifier_base(self->arguments.data[i].identifier, &declaration_line);
+            build_simple_identifier(self->arguments.data[i].identifier, &declaration_line);
         }
     }
     strf(&declaration_line, hoisted ? ");" : ") {");
@@ -30,6 +29,10 @@ static void function_declaration_compiler_hoisted(FunctionDeclaration* const sel
     if(hoisted) {
         compiler->open_section = previous_section;
         return;
+    }
+
+    for(size_t i = 0; i < self->variable_declarations.size; i++) {
+        compile(self->variable_declarations.data[i], &declaration_line, compiler);
     }
 
     compile(self->body, &declaration_line, compiler);
@@ -43,11 +46,15 @@ void comp_FunctionDeclaration(void* void_self, String* line, Compiler* compiler)
     (void) line;
     FunctionDeclaration* self = void_self;
 
-    if(self->identifier.is_external || self->compilation_state == CompilationSkip
-       || (self->generics.base_type_arguments.size && !self->generics.type_arguments_stack.size))
+    if(self->identifier.is_external || (self->generics.base_type_arguments.size
+                                        && !self->generics.type_arguments_stack.size))
         return;
 
-    function_declaration_compiler_hoisted(self, compiler, true);
-    self->compilation_state = CompilationSkip;
-    function_declaration_compiler_hoisted(self, compiler, false);
+    String identifier = { 0 };
+    if(!resolve_identifier(self->identifier, &identifier)) {
+        function_declaration_compiler_hoisted(self, compiler, identifier, true);
+        function_declaration_compiler_hoisted(self, compiler, identifier, false);
+    }
+
+    free(identifier.data);
 }

--- a/src/compiler/righthand/declaration/identifier.c
+++ b/src/compiler/righthand/declaration/identifier.c
@@ -2,7 +2,7 @@
 
 #include "../../../parser/type/stringify_type.h"
 
-StringHashSet global_c_keywords = 0;
+DeclarationHashMap global_declaration_space = 0;
 
 void populate_global_c_keywords() {
     // https://en.cppreference.com/w/c/keyword.html
@@ -16,75 +16,84 @@ void populate_global_c_keywords() {
     };
 
     for(int i = 0; i < sizeof(keywords) / sizeof(char*); i++) {
-        put(&global_c_keywords, ((String) { strlen(keywords[i]), 0, keywords[i] }));
+        put(&global_declaration_space, ((String) { strlen(keywords[i]), 0, keywords[i] }), NULL);
     }
 }
 
 DeclarationHashMap global_function_identifiers = 0;
 
-void compile_identifier_base(const String base, String* line) {
-    strf(line, "%.*s", PRINT(base));
-
-    if(get(global_c_keywords, base)) {
-        strf(line, "_");
+static void prevent_keyword(String* const identifier_builder) {
+    Declaration** defined_declaration = get(global_declaration_space, *identifier_builder);
+    if(defined_declaration && !*defined_declaration) {
+        strf(identifier_builder, "_");
     }
 }
 
-void compile_identifier(const Identifier identifier, String* line) {
-    String result = { 0 };
+void build_simple_identifier(const String identifier, String* const application) {
+    String identifier_builder = { 0 };
 
-    if(!identifier.is_external) {
+    strf(&identifier_builder, "%.*s", FMT(identifier));
+    prevent_keyword(&identifier_builder);
+
+    strf(application, "%.*s", FMT(identifier_builder));
+    free(identifier_builder.data);
+}
+
+static void build_identifier_base(const Identifier identifier, String* const identifier_builder) {
+    if(!identifier.is_external && !(identifier.parent_declaration->id == NodeVariableDeclaration
+                                    && identifier.parent_declaration->VariableDeclaration.compilation_state ==
+                                    CompilationHoisted)) {
         if(identifier.parent_scope && identifier.parent_scope->id == NodeFunctionDeclaration) {
             const Identifier parent_ident = identifier.parent_scope->FunctionDeclaration.identifier;
-            compile_identifier(parent_ident, &result);
-            strf(&result, "__");
+            build_identifier_base(parent_ident, identifier_builder);
+            strf(identifier_builder, "__");
         }
 
         if(identifier.parent_scope && identifier.parent_scope->id == NodeStructType
            && !(identifier.parent_declaration->id == NodeVariableDeclaration
                 && !(identifier.parent_declaration->type->flags & fType))) {
             const Identifier parent_ident = ((StructType*) (void*) identifier.parent_scope)->parent->identifier;
-            compile_identifier(parent_ident, &result);
-            strf(&result, "__");
+            build_identifier_base(parent_ident, identifier_builder);
+            strf(identifier_builder, "__");
         }
 
         if(identifier.reference_structure) {
             const Identifier parent_ident = identifier.reference_structure->parent->identifier;
-            compile_identifier(parent_ident, &result);
-            strf(&result, "__");
+            build_identifier_base(parent_ident, identifier_builder);
+            strf(identifier_builder, "__");
         }
     }
 
-    // TODO: change `PRINT` macro to `FMT` or `STRFMT`
-    compile_identifier_base(identifier.base, &result);
+    strf(identifier_builder, "%.*s", FMT(identifier.base));
 
     if(identifier.parent_declaration->generics.type_arguments_stack.size && !identifier.is_external) {
-        stringify_generics(&result, last(identifier.parent_declaration->generics.type_arguments_stack),
+        stringify_generics(identifier_builder, last(identifier.parent_declaration->generics.type_arguments_stack),
                            StringifyAlphaNumeric);
     }
+}
 
-    if(identifier.function_declaration_counter) strf(&result, "%u", identifier.function_declaration_counter);
+void build_full_identifier(const Identifier identifier, String* const application) {
+    String identifier_builder = { 0 };
 
-    if(!identifier.is_external && !identifier.function_declaration_counter
-       && identifier.parent_declaration->id == NodeFunctionDeclaration) {
-        const size_t initial_size = result.size;
-        unsigned counter = 0;
-        Declaration** existing_declaration;
+    build_identifier_base(identifier, &identifier_builder);
+    prevent_keyword(&identifier_builder);
 
-        while(((existing_declaration = get(global_function_identifiers, result)))
-              && *existing_declaration != identifier.parent_declaration) {
-            result.size = initial_size;
-            strf(&result, "%u", ++counter);
-        }
+    strf(application, "%.*s", FMT(identifier_builder));
+    free(identifier_builder.data);
+}
 
-        if(counter) {
-            identifier.parent_declaration->identifier.function_declaration_counter = counter;
-        }
+bool resolve_identifier(const Identifier identifier, String* const identifier_builder) {
+    build_identifier_base(identifier, identifier_builder);
 
-        if(!existing_declaration) {
-            put(&global_function_identifiers, result, identifier.parent_declaration);
-        }
+    Declaration** defined_declaration;
+    while(((defined_declaration = get(global_declaration_space, *identifier_builder)))
+          && *defined_declaration != identifier.parent_declaration) {
+        strf(identifier_builder, "_");
     }
 
-    strf(line, "%.*s", PRINT(result));
+    if(!defined_declaration) {
+        put(&global_declaration_space, *identifier_builder, identifier.parent_declaration);
+    }
+
+    return defined_declaration;
 }

--- a/src/compiler/righthand/declaration/identifier.h
+++ b/src/compiler/righthand/declaration/identifier.h
@@ -3,15 +3,14 @@
 
 #include "../../compiler.h"
 
-typedef HashMap(UsableVoid) StringHashSet;
-
-extern StringHashSet global_c_keywords;
-extern DeclarationHashMap global_function_identifiers;
-
-void compile_identifier_base(String base, String* line);
-
-void compile_identifier(Identifier identifier, String* line);
+extern DeclarationHashMap global_declaration_space;
 
 void populate_global_c_keywords();
+
+void build_simple_identifier(String identifier, String* application);
+
+void build_full_identifier(Identifier identifier, String* application);
+
+bool resolve_identifier(Identifier identifier, String* identifier_builder);
 
 #endif

--- a/src/compiler/righthand/declaration/struct_declaration.c
+++ b/src/compiler/righthand/declaration/struct_declaration.c
@@ -6,24 +6,27 @@ void comp_StructDeclaration(void* void_self, String* line, Compiler* compiler) {
     StructDeclaration* const self = void_self;
     StructType* const struct_type = (void*) self->type;
 
-    if(self->identifier.is_external || self->compilation_state == CompilationSkip) return;
+    if(self->identifier.is_external) return;
 
-    String typedef_line = strf(0, "struct ");
-    compile_identifier(self->identifier, &typedef_line);
+    String identifier = { 0 };
+    if(resolve_identifier(self->identifier, &identifier)) {
+        if(self->compilation_state == CompilationIntermediate) {
+            push(&compiler->sections.data[0].lines, strf(0, "struct %.*s;", FMT(identifier)));
+            self->compilation_state = CompilationUnused;
+        }
 
-    if(self->compilation_state == CompilationIntermediate) {
-        push(&compiler->sections.data[0].lines, typedef_line);
-        self->compilation_state = CompilationUnused;
+        free(identifier.data);
         return;
     }
 
+    String typedef_line = strf(0, "struct %.*s", FMT(identifier));
     self->compilation_state = CompilationIntermediate;
 
     strf(&typedef_line, " { ");
     for(size_t i = 0; i < struct_type->fields.size; i++) {
         compile(struct_type->fields.data[i].type, &typedef_line, compiler);
         strf(&typedef_line, " ");
-        compile_identifier_base(struct_type->fields.data[i].identifier, &typedef_line);
+        build_simple_identifier(struct_type->fields.data[i].identifier, &typedef_line);
         strf(&typedef_line, "; ");
     }
     strf(&typedef_line, "};");

--- a/src/compiler/righthand/declaration/struct_declaration.c
+++ b/src/compiler/righthand/declaration/struct_declaration.c
@@ -1,0 +1,42 @@
+#include "struct_declaration.h"
+
+#include "identifier.h"
+
+void comp_StructDeclaration(void* void_self, String* line, Compiler* compiler) {
+    StructDeclaration* const self = void_self;
+    StructType* const struct_type = (void*) self->type;
+
+    if(self->identifier.is_external || self->compilation_state == CompilationSkip) return;
+
+    String typedef_line = strf(0, "struct ");
+    compile_identifier(self->identifier, &typedef_line);
+
+    if(self->compilation_state == CompilationIntermediate) {
+        push(&compiler->sections.data[0].lines, typedef_line);
+        self->compilation_state = CompilationUnused;
+        return;
+    }
+
+    self->compilation_state = CompilationIntermediate;
+
+    strf(&typedef_line, " { ");
+    for(size_t i = 0; i < struct_type->fields.size; i++) {
+        compile(struct_type->fields.data[i].type, &typedef_line, compiler);
+        strf(&typedef_line, " ");
+        compile_identifier_base(struct_type->fields.data[i].identifier, &typedef_line);
+        strf(&typedef_line, "; ");
+    }
+    strf(&typedef_line, "};");
+
+    push(&compiler->sections.data[0].lines, typedef_line);
+    compile(struct_type->static_body, line, compiler);
+
+    if(!struct_type->reference_structures) return;
+    for(size_t i = 0; i < sizeof(*struct_type->reference_structures) / sizeof(**struct_type->reference_structures); i++) {
+        for(size_t j = 0; j < (*struct_type->reference_structures)[i].size; j++) {
+            compile(&(*struct_type->reference_structures)[i].data[j].v, line, compiler);
+        }
+    }
+
+    self->compilation_state = CompilationSkip;
+}

--- a/src/compiler/righthand/declaration/struct_declaration.h
+++ b/src/compiler/righthand/declaration/struct_declaration.h
@@ -1,0 +1,8 @@
+#ifndef COMPILER_STRUCT_DECLARATION_H
+#define COMPILER_STRUCT_DECLARATION_H
+
+#include "../../compiler.h"
+
+void comp_StructDeclaration(void* void_self, String* line, Compiler* compiler);
+
+#endif

--- a/src/compiler/righthand/declaration/variable_declaration.c
+++ b/src/compiler/righthand/declaration/variable_declaration.c
@@ -31,7 +31,7 @@ void comp_VariableDeclaration(void* void_self, String* line, Compiler* compiler)
     VariableDeclaration* const self = void_self;
 
     if((self->generics.base_type_arguments.size && !self->generics.type_arguments_stack.size)
-       || self->identifier.is_external)
+       || self->identifier.is_external || self->skip_compilation)
         return;
 
     if(self->const_value && self->const_value->flags & fType) {
@@ -40,8 +40,6 @@ void comp_VariableDeclaration(void* void_self, String* line, Compiler* compiler)
         close_type(opened.actions, 0);
         return;
     }
-
-    if(self->is_inline) return;
 
     String decl_line = new_line(compiler);
     line = &decl_line;

--- a/src/compiler/righthand/declaration/variable_declaration.c
+++ b/src/compiler/righthand/declaration/variable_declaration.c
@@ -7,11 +7,8 @@ void comp_VariableDeclaration(void* void_self, String* line, Compiler* compiler)
     VariableDeclaration* const self = void_self;
 
     if((self->generics.base_type_arguments.size && !self->generics.type_arguments_stack.size)
-       || self->identifier.is_external || self->compilation_state == CompilationSkip
-       || (self->const_value && self->const_value->flags & fType))
+       || self->identifier.is_external || (self->const_value && self->const_value->flags & fType))
         return;
-
-    self->compilation_state = CompilationSkip;
 
     // if(self->const_value && self->const_value->flags & fType) {
     //     const OpenedType opened = open_type((void*) self->const_value, 0);
@@ -25,7 +22,7 @@ void comp_VariableDeclaration(void* void_self, String* line, Compiler* compiler)
 
     compile(self->type, line, compiler);
     strf(line, self->type->flags & fConst ? " const " : " ");
-    compile_identifier(self->identifier, line);
+    build_full_identifier(self->identifier, line);
 
     if(self->const_value) {
         strf(line, " = ");

--- a/src/compiler/righthand/declaration/variable_declaration.c
+++ b/src/compiler/righthand/declaration/variable_declaration.c
@@ -3,43 +3,22 @@
 #include "identifier.h"
 #include "../../../parser/type/types.h"
 
-static void compile_struct_declaration(StructType* self, String* line, Compiler* compiler) {
-    String typedef_line = strf(0, "struct ");
-    compile_identifier(self->parent->identifier, &typedef_line);
-
-    strf(&typedef_line, " { ");
-    for(size_t i = 0; i < self->fields.size; i++) {
-        compile(self->fields.data[i].type, &typedef_line, compiler);
-        strf(&typedef_line, " ");
-        compile_identifier_base(self->fields.data[i].identifier, &typedef_line);
-        strf(&typedef_line, "; ");
-    }
-    strf(&typedef_line, "};");
-
-    push(&compiler->sections.data[0].lines, typedef_line);
-    compile(self->static_body, line, compiler);
-
-    if(!self->reference_structures) return;
-    for(size_t i = 0; i < sizeof(*self->reference_structures) / sizeof(**self->reference_structures); i++) {
-        for(size_t j = 0; j < (*self->reference_structures)[i].size; j++) {
-            compile(&(*self->reference_structures)[i].data[j].v, line, compiler);
-        }
-    }
-}
-
 void comp_VariableDeclaration(void* void_self, String* line, Compiler* compiler) {
     VariableDeclaration* const self = void_self;
 
     if((self->generics.base_type_arguments.size && !self->generics.type_arguments_stack.size)
-       || self->identifier.is_external || self->skip_compilation)
+       || self->identifier.is_external || self->compilation_state == CompilationSkip
+       || (self->const_value && self->const_value->flags & fType))
         return;
 
-    if(self->const_value && self->const_value->flags & fType) {
-        const OpenedType opened = open_type((void*) self->const_value, 0);
-        compile_struct_declaration((void*) opened.type, line, compiler);
-        close_type(opened.actions, 0);
-        return;
-    }
+    self->compilation_state = CompilationSkip;
+
+    // if(self->const_value && self->const_value->flags & fType) {
+    //     const OpenedType opened = open_type((void*) self->const_value, 0);
+    //     compile_struct_declaration((void*) opened.type, line, compiler);
+    //     close_type(opened.actions, 0);
+    //     return;
+    // }
 
     String decl_line = new_line(compiler);
     line = &decl_line;

--- a/src/compiler/statement/scope.c
+++ b/src/compiler/statement/scope.c
@@ -11,11 +11,6 @@ void comp_Scope(void* void_self, String* line, Compiler* compiler) {
     CompilerSection* const section = compiler->sections.data + compiler->open_section;
     strf(&section->indent, "    ");
 
-    for(size_t i = 0; i < self->hoisted_declarations.size; i++) {
-        if(self->hoisted_declarations.data[i]->is_inline) continue;
-        compile(self->hoisted_declarations.data[i], line, compiler);
-    }
-
     for(size_t i = 0; i < self->children.size; i++) {
         compile(self->children.data[i], line, compiler);
     }

--- a/src/compiler/statement/statement.c
+++ b/src/compiler/statement/statement.c
@@ -25,10 +25,10 @@ void comp_ControlStatement(void* void_self, String* line, Compiler* compiler) {
     ControlStatement* const self = void_self;
 
     String block = new_line(compiler);
-    strf(&block, "%.*s(", PRINT(self->keyword));
+    strf(&block, "%.*s(", FMT(self->keyword));
 
     for (size_t i = 0; i < self->conditions.size; i++) {
-        if (i) strf(&block, ";");
+        if (i) strf(&block, "; ");
         compile(self->conditions.data[i], &block, compiler);
     }
 

--- a/src/compiler/types/types.c
+++ b/src/compiler/types/types.c
@@ -13,7 +13,7 @@ void comp_FunctionType(void* void_self, String* line, Compiler* compiler) {
     FunctionType* self = void_self;
 
     String identifier = strf(0, "__Function__");
-    compile_identifier(self->declaration->identifier, &identifier);
+    resolve_identifier(self->declaration->identifier, &identifier);
 
     bool* type_definition_state = get(self->type_definitions, identifier);
 
@@ -22,7 +22,7 @@ void comp_FunctionType(void* void_self, String* line, Compiler* compiler) {
 
         String typedef_line = strf(0, "typedef ");
         compile(self->signature.data[0], &typedef_line, compiler);
-        strf(&typedef_line, " (*%.*s)(", PRINT(identifier));
+        strf(&typedef_line, " (*%.*s)(", FMT(identifier));
 
         for(size_t i = 1; i < self->signature.size; i++) {
             if(i > 1) strf(&typedef_line, ", ");
@@ -38,7 +38,7 @@ void comp_FunctionType(void* void_self, String* line, Compiler* compiler) {
         return;
     }
 
-    strf(line, "%.*s", PRINT(identifier));
+    strf(line, "%.*s", FMT(identifier));
 }
 
 void comp_GenericReference(void* void_self, String* line, Compiler* compiler) {
@@ -51,6 +51,6 @@ void comp_StructType(void* void_self, String* line, Compiler* compiler) {
     StructType* self = void_self;
 
     strf(line, "struct ");
-    compile_identifier(self->parent->identifier, line);
+    resolve_identifier(self->parent->identifier, line);
 }
 

--- a/src/compiler/types/types.c
+++ b/src/compiler/types/types.c
@@ -30,7 +30,7 @@ void comp_FunctionType(void* void_self, String* line, Compiler* compiler) {
         }
 
         strf(&typedef_line, ");");
-        push(&compiler->sections.data[0].lines, typedef_line);
+        push(&compiler->sections.data[1].lines, typedef_line);
 
         *get(self->type_definitions, identifier) = true;
     } else if(!*type_definition_state) {

--- a/src/include/vector-string.h
+++ b/src/include/vector-string.h
@@ -25,6 +25,6 @@ bool streq(String a, String b);
 
 uint32_t fnv1a_u32_hash(String string);
 
-#define PRINT(string) (int) (string).size, (string).data
+#define FMT(string) (int) (string).size, (string).data
 
 #endif // VECTOR_STRING_H

--- a/src/main.c
+++ b/src/main.c
@@ -9,7 +9,7 @@
 #include "parser/keywords.h"
 #include "compiler/righthand/declaration/identifier.h"
 
-#define QUARK_VERSION "0.4.feat-lambda-1"
+#define QUARK_VERSION "0.4 (chore/unused-declarations)"
 #define QUARK_STABILITY "dev"
 
 FunctionDeclaration* entry_declaration() {
@@ -120,7 +120,7 @@ int main(int argc, char** argv) {
     populate_keyword_table();
     populate_global_c_keywords();
 
-    push(&entry->body->children, eval_w("lib::std", "import lib::std;", &parser, &statement));
+    // push(&entry->body->children, eval_w("lib::std", "import lib::std;", &parser, &statement));
     const NodeVector body = collect_until(&parser, &statement, 0, 0);
     resv(&entry->body->children, body.size);
     for(size_t i = 0; i < body.size; i++) {

--- a/src/main.c
+++ b/src/main.c
@@ -19,7 +19,7 @@ FunctionDeclaration* entry_declaration() {
 
     FunctionDeclaration* declaration = (void*) new_node((Node) {
         .FunctionDeclaration = {
-            .id = NodeFunctionDeclaration,
+            .id = NodeEntryFunctionDeclaration,
             .type = (void*) function_type,
             .identifier = { .base = String("main") },
             .body = new_scope(NULL),
@@ -27,6 +27,7 @@ FunctionDeclaration* entry_declaration() {
     });
     declaration->identifier.parent_declaration = (void*) declaration;
     function_type->declaration = declaration;
+    declaration->body->parent = (void*) declaration;
 
     return declaration;
 }
@@ -146,7 +147,7 @@ int main(int argc, char** argv) {
 
     for(size_t i = 0; i < compiler.sections.size; i++) {
         for(size_t j = 0; j < compiler.sections.data[i].lines.size; j++) {
-            fprintf(out, "%.*s\n", PRINT(compiler.sections.data[i].lines.data[j]));
+            fprintf(out, "%.*s\n", FMT(compiler.sections.data[i].lines.data[j]));
         }
         if(i) fprintf(out, "\n");
     }

--- a/src/main.c
+++ b/src/main.c
@@ -121,7 +121,7 @@ int main(int argc, char** argv) {
     populate_keyword_table();
     populate_global_c_keywords();
 
-    // push(&entry->body->children, eval_w("lib::std", "import lib::std;", &parser, &statement));
+    push(&entry->body->children, eval_w("lib::std", "import lib::std;", &parser, &statement));
     const NodeVector body = collect_until(&parser, &statement, 0, 0);
     resv(&entry->body->children, body.size);
     for(size_t i = 0; i < body.size; i++) {

--- a/src/parser/literal/wrapper.c
+++ b/src/parser/literal/wrapper.c
@@ -1,7 +1,7 @@
 #include "wrapper.h"
 
+// TODO: handle generics here
 Wrapper* variable_of(Declaration* declaration, const Trace trace, unsigned long flags) {
-    declaration->observerd = true;
     flags |= fConstExpr | fMutable | (declaration->flags & fType);
 
     return (void*) new_node((Node) {

--- a/src/parser/nodes/fields.h
+++ b/src/parser/nodes/fields.h
@@ -5,6 +5,8 @@
 
 #include "../../tokenizer/tokenizer.h"
 
+// TODO: remove bit lengths from booleans
+
 #define NODE_FIELDS \
     NodeID id; \
     uint32_t flags; \
@@ -19,8 +21,7 @@
     struct Identifier identifier; \
     union Node* const_value; \
     struct Generics generics; \
-    bool is_inline : 1, \
-         observerd : 1
+    bool skip_compilation;
 
 typedef struct Compiler Compiler;
 typedef union Node Node;

--- a/src/parser/nodes/fields.h
+++ b/src/parser/nodes/fields.h
@@ -21,7 +21,7 @@
     struct Identifier identifier; \
     union Node* const_value; \
     struct Generics generics; \
-    bool skip_compilation;
+    uint8_t compilation_state;
 
 typedef struct Compiler Compiler;
 typedef union Node Node;

--- a/src/parser/nodes/nodes.h
+++ b/src/parser/nodes/nodes.h
@@ -31,6 +31,7 @@ typedef enum : uint32_t {
     NodeFunctionCall,
     NodeVariableDeclaration,
     NodeFunctionDeclaration,
+    NodeEntryFunctionDeclaration,
     NodeStructDeclaration,
 
     NodeScope,
@@ -43,6 +44,7 @@ enum {
     CompilationUnused,
     CompilationSkip,
     CompilationIntermediate,
+    CompilationHoisted,
 };
 
 enum {

--- a/src/parser/nodes/nodes.h
+++ b/src/parser/nodes/nodes.h
@@ -31,12 +31,19 @@ typedef enum : uint32_t {
     NodeFunctionCall,
     NodeVariableDeclaration,
     NodeFunctionDeclaration,
+    NodeStructDeclaration,
 
     NodeScope,
     NodeStatementWrapper,
     NodeReturnStatement,
     NodeControlStatement,
 } NodeID;
+
+enum {
+    CompilationUnused,
+    CompilationSkip,
+    CompilationIntermediate,
+};
 
 enum {
     fType = 1 << 0,
@@ -68,6 +75,7 @@ enum {
 #include "righthand/function_call.h"
 #include "righthand/declaration/variable_declaration.h"
 #include "righthand/declaration/function_declaration.h"
+#include "righthand/declaration/struct_declaration.h"
 
 #include "statement/statement_wrapper.h"
 #include "statement/return_statement.h"
@@ -91,6 +99,7 @@ union Declaration {
 
     FunctionDeclaration FunctionDeclaration;
     VariableDeclaration VariableDeclaration;
+    StructDeclaration StructDeclaration;
 };
 
 union Node {
@@ -112,6 +121,7 @@ union Node {
     FunctionCall FunctionCall;
     VariableDeclaration VariableDeclaration;
     FunctionDeclaration FunctionDeclaration;
+    StructDeclaration StructDeclaration;
 
     StatementWrapper StatementWrapper;
     ReturnStatement ReturnStatement;

--- a/src/parser/nodes/righthand/declaration/function_declaration.h
+++ b/src/parser/nodes/righthand/declaration/function_declaration.h
@@ -10,10 +10,13 @@ typedef struct Argument {
 
 typedef Vector(Argument) ArgumentVector;
 
+typedef Vector(VariableDeclaration*) VariableDeclarationVector;
+
 typedef struct FunctionDeclaration {
     DECLARATION_FIELDS;
     ArgumentVector arguments;
     struct Scope* body;
+    VariableDeclarationVector variable_declarations;
 } FunctionDeclaration;
 
 #endif

--- a/src/parser/nodes/righthand/declaration/identifier.h
+++ b/src/parser/nodes/righthand/declaration/identifier.h
@@ -9,7 +9,6 @@ typedef struct Identifier {
     Declaration* parent_scope;
     Declaration* parent_declaration;
     StructType* reference_structure;
-    unsigned function_declaration_counter;
     bool is_external : 1;
 } Identifier;
 

--- a/src/parser/nodes/righthand/declaration/struct_declaration.h
+++ b/src/parser/nodes/righthand/declaration/struct_declaration.h
@@ -1,0 +1,10 @@
+#ifndef NODE_STRUCT_DECLARATION_H
+#define NODE_STRUCT_DECLARATION_H
+
+#include "../../fields.h"
+
+typedef struct StructDeclaration {
+    DECLARATION_FIELDS;
+} StructDeclaration;
+
+#endif

--- a/src/parser/nodes/statement/scope.h
+++ b/src/parser/nodes/statement/scope.h
@@ -11,7 +11,7 @@ typedef struct Scope {
     NODE_FIELDS;
     NodeVector children;
     DeclarationHashMap variables;
-    DeclarationVector hoisted_declarations;
+    // DeclarationVector hoisted_declarations;
     Declaration* parent;
     Node* result_value;
     bool wrap_with_brackets : 1;

--- a/src/parser/nodes/type/struct_type.h
+++ b/src/parser/nodes/type/struct_type.h
@@ -17,7 +17,7 @@ typedef struct StructType {
     TYPE_FIELDS;
     Vector(StructField) fields;
     struct Scope* static_body;
-    struct VariableDeclaration* parent;
+    struct StructDeclaration* parent;
     ScopeHashMap reference_structures;
 } StructType;
 

--- a/src/parser/righthand/assignment.c
+++ b/src/parser/righthand/assignment.c
@@ -3,7 +3,7 @@
 void check_assignable(Node* node, MessageVector* messages) {
     if(node->flags & fMutable && !(node->type->flags & fConst)) return;
     push(messages, REPORT_ERR(node->trace,
-        strf(0, "'\33[35m%.*s\33[0m' is not assignable", PRINT(node->trace.source))));
+        strf(0, "'\33[35m%.*s\33[0m' is not assignable", FMT(node->trace.source))));
 }
 
 Node* parse_postfix_assignment(Node* lefthand, Parser* parser) {

--- a/src/parser/righthand/declaration/declaration.c
+++ b/src/parser/righthand/declaration/declaration.c
@@ -8,7 +8,7 @@ Message see_declaration(Declaration* declaration, Trace trace) {
     if(!declaration) {
         return REPORT_INFO((Trace) { 0 }, String("declaration not found"));
     }
-    return REPORT_INFO(declaration->trace, strf(0, "declaration of '\33[35m%.*s\33[0m'", PRINT(trace.source)));
+    return REPORT_INFO(declaration->trace, strf(0, "declaration of '\33[35m%.*s\33[0m'", FMT(trace.source)));
 }
 
 Node* parse_declaration(Node* type, Token identifier, Parser* parser) {

--- a/src/parser/righthand/declaration/function.c
+++ b/src/parser/righthand/declaration/function.c
@@ -39,8 +39,9 @@ static Argument create_self_literal(const Trace trace, StructType* const parent_
     } else {
         Wrapper* wrapper = variable_of((void*) parent_struct->parent, trace, 0);
         apply_type_arguments(wrapper, parser);
-        type = wrapper->type;
-        unbox((void*) wrapper);
+        type = (void*) wrapper;
+        // type = wrapper->type;
+        // unbox((void*) wrapper);
     }
 
     const Argument argument = {
@@ -87,7 +88,7 @@ static void parse_function_arguments(FunctionType* function_type, FunctionDeclar
         if(!(argument.type->flags & fType)) {
             push(parser->tokenizer->messages,
                  REPORT_ERR(argument.type->trace, strf(0, "'\33[35m%.*s\33[0m' is not a type",
-                     PRINT(argument.type->trace.source))));
+                     FMT(argument.type->trace.source))));
         }
 
         if(argument.identifier.size) {
@@ -95,7 +96,7 @@ static void parse_function_arguments(FunctionType* function_type, FunctionDeclar
                 .VariableDeclaration = {
                     .id = NodeVariableDeclaration,
                     .type = argument.type,
-                    .compilation_state = CompilationSkip,
+                    .compilation_state = CompilationHoisted,
                     .identifier = {
                         .base = argument.identifier,
                         .parent_scope = (void*) parser->stack.data[0],

--- a/src/parser/righthand/declaration/function.c
+++ b/src/parser/righthand/declaration/function.c
@@ -95,6 +95,7 @@ static void parse_function_arguments(FunctionType* function_type, FunctionDeclar
                 .VariableDeclaration = {
                     .id = NodeVariableDeclaration,
                     .type = argument.type,
+                    .compilation_state = CompilationSkip,
                     .identifier = {
                         .base = argument.identifier,
                         .parent_scope = (void*) parser->stack.data[0],
@@ -142,7 +143,6 @@ Node* parse_function_declaration(Type* return_type, IdentifierInfo info, Parser*
     push(&parser->stack, declaration->body);
     traverse_type(return_type, NULL, &recycle_missing_generics, parser, TraverseGenerics);
 
-    push(&info.declaration_scope->hoisted_declarations, (void*) declaration);
     put(&info.declaration_scope->variables, info.identifier.base, (void*) declaration);
 
     parse_function_arguments(function_type, declaration, parser, false);
@@ -193,8 +193,6 @@ Node* parse_function_lambda(Type* return_type, Parser* parser) {
         pop(&parser->stack);
         return (void*) function_type;
     }
-
-    push(&parser->stack.data[parser->stack.size - 2]->hoisted_declarations, (void*) declaration);
 
     Token operator;
     switch((operator = next(parser->tokenizer)).type) {

--- a/src/parser/righthand/declaration/variable.c
+++ b/src/parser/righthand/declaration/variable.c
@@ -17,7 +17,6 @@ Node* parse_variable_declaration(Type* type, IdentifierInfo info, Parser* parser
     });
     declaration->identifier.parent_declaration = (void*) declaration;
 
-    push(&info.declaration_scope->hoisted_declarations, (void*) declaration);
     put(&info.declaration_scope->variables, info.identifier.base, (void*) declaration);
 
     if(type->flags & fConst && try(parser->tokenizer, '=', 0)) {
@@ -42,11 +41,10 @@ Node* create_temp_variable(Node* const value, Parser* const parser, NodeVector* 
                 .base = strf(0, "__qv%u", id++),
                 .parent_scope = (void*) last(parser->stack),
             },
-            .observerd = true,
         },
     });
     declaration->VariableDeclaration.identifier.parent_declaration = declaration;
-    push(&last(parser->stack)->hoisted_declarations, declaration);
+    push(collector, (void*) declaration);
 
     Node* const variable = new_node((Node) {
         .External = {

--- a/src/parser/righthand/declaration/variable.c
+++ b/src/parser/righthand/declaration/variable.c
@@ -25,6 +25,12 @@ Node* parse_variable_declaration(Type* type, IdentifierInfo info, Parser* parser
                     parser->tokenizer->messages, 0);
     }
 
+    FunctionDeclaration* const parent = (void*) last(parser->stack)->parent;
+    if(parent->id == NodeFunctionDeclaration || parent->id == NodeEntryFunctionDeclaration) {
+        push(&parent->variable_declarations, declaration);
+        declaration->compilation_state = CompilationHoisted;
+    }
+
     return (void*) variable_of((void*) declaration, declaration->trace, fIgnoreStatement);
 }
 

--- a/src/parser/righthand/field_access.c
+++ b/src/parser/righthand/field_access.c
@@ -43,7 +43,7 @@ Node* parse_field_access(Node* lefthand, Parser* parser) {
 
     if(struct_type->id != NodeStructType) {
         push(parser->tokenizer->messages, REPORT_ERR(lefthand->trace,
-                 strf(0, "'\33[35m%.*s\33[0m' is not a structure", PRINT(lefthand->trace.source))));
+                 strf(0, "'\33[35m%.*s\33[0m' is not a structure", FMT(lefthand->trace.source))));
         close_type(opened.actions, 0);
         return lefthand;
     }
@@ -73,7 +73,7 @@ Node* parse_field_access(Node* lefthand, Parser* parser) {
 
         push(parser->tokenizer->messages,
              REPORT_ERR(field_token.trace, strf(0, "no field named '\33[35m%.*s\33[0m' on struct '\33[35m%.*s\33[0m'",
-                 PRINT(field_token.trace.source), PRINT(lefthand->trace.source))));
+                 FMT(field_token.trace.source), FMT(lefthand->trace.source))));
         push(parser->tokenizer->messages, see_declaration((void*) struct_type, lefthand->trace));
         return lefthand;
     }

--- a/src/parser/righthand/function_call.c
+++ b/src/parser/righthand/function_call.c
@@ -20,13 +20,10 @@ Declaration* fetch_operator_override(Type* type, const String override) {
     return find_in_scope_unwrapped(*overrides_scope, override);
 }
 
-Node* operator_override(Type* type, Node* self, Node* argument, const String override, const Trace trace,
-                        Parser* parser) {
+Node* operator_override_n(Type* type, Node* self, NodeVector arguments, const String override, const Trace trace,
+                          Parser* parser) {
     Declaration* const operator_override = fetch_operator_override(type, override);
     if(!operator_override) return NULL;
-
-    NodeVector arguments = { 0 };
-    push(&arguments, argument);
 
     Wrapper* override_variable = variable_of(operator_override, trace, 0);
     OpenedType const opened_lefthand = open_type(type, 0);
@@ -39,10 +36,18 @@ Node* operator_override(Type* type, Node* self, Node* argument, const String ove
     return call_function((void*) override_variable, arguments, parser);
 }
 
+Node* operator_override(Type* type, Node* self, Node* argument, const String override, const Trace trace,
+                        Parser* parser) {
+    NodeVector arguments = { 0 };
+    push(&arguments, argument);
+    return operator_override_n(type, self, arguments, override, trace, parser);
+}
+
 Node* call_function(Node* function, NodeVector arguments, Parser* const parser) {
     const OpenedType opened_function_type = open_type(function->type, 0);
     FunctionType* const function_type = (void*) opened_function_type.type;
 
+    // TODO: Operator::call override
     if(function_type->id != NodeFunctionType) {
         push(parser->tokenizer->messages, REPORT_ERR(function->trace, String("calling a non-function value")));
         close_type(opened_function_type.actions, 0);

--- a/src/parser/righthand/function_call.h
+++ b/src/parser/righthand/function_call.h
@@ -5,6 +5,9 @@
 
 Declaration* fetch_operator_override(Type* type, String override);
 
+Node* operator_override_n(Type* type, Node* self, NodeVector arguments, const String override, const Trace trace,
+                          Parser* parser);
+
 Node* operator_override(Type* type, Node* self, Node* argument, const String override, const Trace trace,
                         Parser* parser);
 

--- a/src/parser/righthand/righthand.c
+++ b/src/parser/righthand/righthand.c
@@ -55,6 +55,7 @@ Node* expression(Parser* parser) {
 Node* righthand_expression(Node* lefthand, Parser* parser, const unsigned char precedence) {
     RighthandOperator operator;
     while((operator = global_righthand_operator_table[parser->tokenizer->current.type]).precedence) {
+        if(lefthand->flags & fStatementTerminated) break;
         if(operator.precedence >= precedence + (operator.type == RightAssignment)) break;
         if(operator.precedence == 6 && global_righthand_collecting_type_arguments) break;
 

--- a/src/parser/statement/keywords.c
+++ b/src/parser/statement/keywords.c
@@ -17,7 +17,7 @@ Node* keyword_import(const Token token, Parser* parser) {
 
     do {
         const Trace section = expect(parser->tokenizer, TokenIdentifier).trace;
-        strf(&sub_path, "/%.*s", PRINT(section.source));
+        strf(&sub_path, "/%.*s", FMT(section.source));
         full_trace = stretch(full_trace, section);
     } while(try(parser->tokenizer, TokenDoubleColon, NULL));
     expect(parser->tokenizer, ';');
@@ -26,7 +26,7 @@ Node* keyword_import(const Token token, Parser* parser) {
 
     String import_path = { 0 };
     for(size_t i = 0; i < global_library_paths.size; i++) {
-        strf(&import_path, "%s%.*s%c", global_library_paths.data[i], PRINT(sub_path), 0);
+        strf(&import_path, "%s%.*s%c", global_library_paths.data[i], FMT(sub_path), 0);
         char* input_content = fs_readfile(import_path.data);
 
         if(!input_content) {
@@ -45,7 +45,7 @@ Node* keyword_import(const Token token, Parser* parser) {
     }
 
     push(parser->tokenizer->messages,
-         REPORT_ERR(full_trace, strf(0, "unable to open or read '%.*s'", PRINT(import_path))));
+         REPORT_ERR(full_trace, strf(0, "unable to open or read '%.*s'", FMT(import_path))));
     return new_node((Node) { NodeNone });
 }
 

--- a/src/parser/statement/keywords.c
+++ b/src/parser/statement/keywords.c
@@ -89,9 +89,9 @@ Node* keyword_struct(const Token token, Parser* parser) {
     // TODO: create a flag that only allows type to compile if it is pointed to (in reference()) this will prevent
     //  circular types and allow structs to reference themselves within themselves
 
-    VariableDeclaration* declaration = (void*) new_node((Node) {
-        .VariableDeclaration = {
-            .id = NodeVariableDeclaration,
+    StructDeclaration* declaration = (void*) new_node((Node) {
+        .StructDeclaration = {
+            .id = NodeStructDeclaration,
             .flags = fConst | fType,
             .trace = type->trace,
             .type = (void*) type,
@@ -127,7 +127,6 @@ Node* keyword_struct(const Token token, Parser* parser) {
         unbox((void*) field_decl);
         unbox((void*) next_declaration->type);
         unbox(next_declaration);
-        pop(&type->static_body->hoisted_declarations);
     }
 
     NodeVector declarations = { 0 };
@@ -143,7 +142,6 @@ Node* keyword_struct(const Token token, Parser* parser) {
     close_generics_declaration((void*) declaration);
     type->static_body->children = declarations;
 
-    push(&last(parser->stack)->hoisted_declarations, (void*) declaration);
     return new_node((Node) { NodeNone });
 }
 

--- a/src/parser/type/stringify_type.c
+++ b/src/parser/type/stringify_type.c
@@ -48,7 +48,7 @@ static int stringify_acceptor(Type* type, Type* follower, void* void_accumulator
 
         case NodeStructType:
             strf(accumulator->string, accumulator->flags & StringifyAlphaNumeric ? "struct_%.*s" : "struct %.*s",
-                 PRINT(type->StructType.parent->identifier.base));
+                 FMT(type->StructType.parent->identifier.base));
 
             if(type->StructType.parent->generics.base_type_arguments.size) {
                 stringify_generics(accumulator->string, last(type->StructType.parent->generics.type_arguments_stack),

--- a/src/tokenizer/trace.c
+++ b/src/tokenizer/trace.c
@@ -9,7 +9,7 @@ Trace stretch(Trace a, const Trace b) {
 bool print_message(const Message message) {
     if(!message.trace.filename) {
         // TODO: see #1
-        printf("\33[1m%s%s:\33[0m %.*s\n", message.highlight, message.label, PRINT(message.content));
+        printf("\33[1m%s%s:\33[0m %.*s\n", message.highlight, message.label, FMT(message.content));
         return 0;
     }
 
@@ -29,7 +29,7 @@ bool print_message(const Message message) {
     // TODO: see #1
     printf("\33[1m%s:%u:%u: %s%s:\33[0m %.*s\n%4d | %s\n     : %s%.*s\33[0m\n",
            message.trace.filename, message.trace.row, message.trace.col,
-           message.highlight, message.label, PRINT(message.content),
+           message.highlight, message.label, FMT(message.content),
            message.trace.row, line_start,
            message.highlight, (int) sizeof(underline), underline);
 


### PR DESCRIPTION
Unused declarations will no longer be compiled; any declaration is only compiled when a variable that references it is compiled (this does not include structure fields or function arguments).